### PR TITLE
Make DOMAIN part of configuration.yaml non optional

### DIFF
--- a/custom_components/wemportal/__init__.py
+++ b/custom_components/wemportal/__init__.py
@@ -19,7 +19,7 @@ from .wemportalapi import WemPortalApi
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Optional(DOMAIN, default=[]): vol.Schema(
+        DOMAIN: vol.Schema(
             {
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=timedelta(minutes=30)


### PR DESCRIPTION
Fixes https://github.com/erikkastelec/hass-WEM-Portal/issues/25
YAML requires a starting point where to search for the integration - thus the DOMAIN part should not be an optional value to start with.