### PR TITLE
Ensure leistungsanforderung in percent

### DIFF
--- a/custom_components/wemportal/wemportalapi.py
+++ b/custom_components/wemportal/wemportalapi.py
@@ -705,6 +705,9 @@ class WemPortalSpider(Spider):
                         else:
                             unit = None
 
+                    if(name.endswith('leistungsanforderung')):
+                        unit = '%'
+
                     icon_mapper = defaultdict(lambda: "mdi:flash")
                     icon_mapper["°C"] = "mdi:thermometer"
 


### PR DESCRIPTION
Ensure leistungsanforderung is always displayed in percent even if during startup, the leistungsanforderung is "off"