### PR TITLE
attempt to fix #76: "kW (W)" -> "W" and "kW (W)h" -> "Wh"

### DIFF
--- a/custom_components/wemportal/number.py
+++ b/custom_components/wemportal/number.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import get_wemportal_unique_id
 from .const import _LOGGER, DOMAIN
 from homeassistant.helpers.entity import DeviceInfo
+from .utils import fix_unit_of_measurement
 
 
 async def async_setup_platform(
@@ -77,7 +78,7 @@ class WemPortalNumber(CoordinatorEntity, NumberEntity):
         self._last_updated = None
         self._parameter_id = entity_data["ParameterID"]
         self._attr_icon = entity_data["icon"]
-        self._attr_native_unit_of_measurement = entity_data["unit"]
+        self._attr_native_unit_of_measurement = fix_unit_of_measurement(entity_data["unit"])
         self._attr_native_value = entity_data["value"]
         self._attr_native_min_value = entity_data["min_value"]
         self._attr_native_max_value = entity_data["max_value"]

--- a/custom_components/wemportal/sensor.py
+++ b/custom_components/wemportal/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import _LOGGER, DOMAIN
 from . import get_wemportal_unique_id
+from .utils import fix_unit_of_measurement
 
 
 async def async_setup_platform(
@@ -81,7 +82,7 @@ class WemPortalSensor(CoordinatorEntity, SensorEntity):
         )
         self._parameter_id = entity_data["ParameterID"]
         self._attr_icon = entity_data["icon"]
-        self._attr_native_unit_of_measurement = entity_data["unit"]
+        self._attr_native_unit_of_measurement = fix_unit_of_measurement(entity_data["unit"])
         self._attr_native_value = entity_data["value"]
         self._attr_should_poll = False
 

--- a/custom_components/wemportal/switch.py
+++ b/custom_components/wemportal/switch.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import _LOGGER, DOMAIN
 from . import get_wemportal_unique_id
+from .utils import fix_unit_of_measurement
 
 
 async def async_setup_platform(
@@ -83,7 +84,7 @@ class WemPortalSwitch(CoordinatorEntity, SwitchEntity):
 
         self._parameter_id = entity_data["ParameterID"]
         self._attr_icon = entity_data["icon"]
-        self._attr_unit = entity_data["unit"]
+        self._attr_unit = fix_unit_of_measurement(entity_data["unit"])
         self._attr_state = entity_data["value"]
         self._attr_should_poll = False
         self._attr_device_class = "switch"  # type: ignore

--- a/custom_components/wemportal/utils.py
+++ b/custom_components/wemportal/utils.py
@@ -1,7 +1,10 @@
 def fix_unit_of_measurement(uom: str) -> str:
-    """Fix the unit of measurement. WEM Portal uses "kW (W)" for "W" and "kW (W)h" for "Wh"."""
+    """Fix the unit of measurement. WEM Portal uses "kW (W)" for "W" and "kW (W)h" for "Wh". Also fix the casing of some units."""
 
     return {
-        "kW (W)": "W",
-        "kW (W)h": "Wh",
-    }.get(uom, uom)
+        "w": "W",
+        "kw": "kW",
+        "kwh": "kWh",
+        "kw (w)": "W",
+        "kw (w)h": "Wh",
+    }.get(uom.lower(), uom)

--- a/custom_components/wemportal/utils.py
+++ b/custom_components/wemportal/utils.py
@@ -1,0 +1,7 @@
+def fix_unit_of_measurement(uom: str) -> str:
+    """Fix the unit of measurement. WEM Portal uses "kW (W)" for "W" and "kW (W)h" for "Wh"."""
+
+    return {
+        "kW (W)": "W",
+        "kW (W)h": "Wh",
+    }.get(uom, uom)


### PR DESCRIPTION
attempt to fix #76

WEM seems to use `kW (W)` for `W` and `kW (W)h` for `Wh`.

This fix checks the `unit of measurement` value for the above 2 patterns and fixes them to the correct values.