### PR TITLE
Add python-Levenshtein to requirements in manifest.json

### DIFF
--- a/custom_components/wemportal/manifest.json
+++ b/custom_components/wemportal/manifest.json
@@ -12,7 +12,8 @@
     "scrapyscript==1.1.*",
     "scrapy==2.12.*",
     "fuzzywuzzy==0.18.0",
-    "twisted<=24.11.0"
+    "twisted<=24.11.0",
+    "python-Levenshtein==0.27.1"
   ],
   "loggers": ["scrapy"],
   "iot_class": "cloud_polling",


### PR DESCRIPTION
This solves the following warning in the Home Assistant Core logs:

/usr/local/lib/python3.13/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')