### PR TITLE
Add device registration in async_setup_entry

### DIFF
--- a/custom_components/wemportal/__init__.py
+++ b/custom_components/wemportal/__init__.py
@@ -138,6 +138,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # "config": entry.data,
         "coordinator": coordinator,
     }
+
+    # Register the hub device so child devices can reference it via via_device
+    device_registry.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer="Weishaupt",
+        name=entry.title or "WEM Portal",
+        model="WEM Portal",
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
 

--- a/custom_components/wemportal/manifest.json
+++ b/custom_components/wemportal/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/erikkastelec/hass-WEM-Portal",
   "issue_tracker": "https://github.com/erikkastelec/hass-WEM-Portal/issues",
   "dependencies": [],
-  "version": "1.5.12",
+  "version": "1.5.13",
   "codeowners": [
     "@erikkastelec"
   ],


### PR DESCRIPTION
* Added logic in `custom_components/wemportal/__init__.py` to register the hub device in the device registry, allowing child devices to reference it via `via_device`. Fixes #119 
