### PR TITLE
Fix "unit has changed" statistics repair for sensors with intermittent empty unit

### DIFF
--- a/custom_components/wemportal/sensor.py
+++ b/custom_components/wemportal/sensor.py
@@ -107,7 +107,7 @@ class WemPortalSensor(CoordinatorEntity, SensorEntity):
         )
         self._parameter_id = entity_data["ParameterID"]
         self._attr_icon = entity_data["icon"]
-        self._attr_native_unit_of_measurement = uom
+        self._attr_native_unit_of_measurement = uom if uom != "" else None
         self._attr_native_value = self._validated_native_value(val, uom)
         self._attr_should_poll = False
 
@@ -146,8 +146,7 @@ class WemPortalSensor(CoordinatorEntity, SensorEntity):
             val, uom = fix_value_and_uom(entity_data["value"], entity_data["unit"])
             self._attr_native_value = self._validated_native_value(val, uom)
 
-            # set uom if it references a valid non-trivial unit of measurement
-            if not uom in (None, ""):
+            if uom not in (None, ""):
                 self._attr_native_unit_of_measurement = uom
 
             _LOGGER.debug(f'Update sensor: {self._attr_name}: "{self._attr_native_value}" [{self._attr_native_unit_of_measurement}]')


### PR DESCRIPTION
When the WEM Portal API returns an empty unit string (e.g. heat pump idle), the sensor initialized with "" as its unit, conflicting with the °C stored in the statistics database. This triggered a "unit has changed" repair on every HA restart while the device was idle.

Setting None instead of "" on init tells HA the unit is not yet known, causing it to skip statistics validation until the first update delivers the real unit. The existing runtime guard already prevents overwriting a good unit with an empty one.